### PR TITLE
The 64bit mode requires also EFER_LMA flag in sregs->efer.

### DIFF
--- a/kvm-hello-world.c
+++ b/kvm-hello-world.c
@@ -396,7 +396,7 @@ static void setup_long_mode(struct vm *vm, struct kvm_sregs *sregs)
 	sregs->cr4 = CR4_PAE;
 	sregs->cr0
 		= CR0_PE | CR0_MP | CR0_ET | CR0_NE | CR0_WP | CR0_AM | CR0_PG;
-	sregs->efer = EFER_LME;
+	sregs->efer = EFER_LME | EFER_LMA;
 
 	setup_64bit_code_segment(sregs);
 }


### PR DESCRIPTION
Patch author is Andreas Neubaum <Andreas.Neubaum1@gmx.de> @AnonymousII,
@justinc1 just copied his solution.

Tested on Ubuntu 18.04 LTS 64 bit by @AnonymousII.
Tested on Fedora 27 64 bit by @justinc1.

Fixes #5.

Signed-off-by: Justin Cinkelj <justin.cinkelj@xlab.si>